### PR TITLE
Fix to use new namespace to import RN 40+ libs

### DIFF
--- a/ios/RNAlipay/RNAlipay.h
+++ b/ios/RNAlipay/RNAlipay.h
@@ -1,9 +1,9 @@
-#import "RCTLog.h"
-#import "RCTConvert.h"
-#import "RCTBridge.h"
-#import "RCTUtils.h"
-#import "RCTEventDispatcher.h"
-#import "RCTBridgeModule.h"
+#import <React/RCTLog.h>
+#import <React/RCTConvert.h>
+#import <React/RCTBridge.h>
+#import <React/RCTUtils.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTBridgeModule.h>
 #import <UIKit/UIKit.h>
 
 @interface RNAlipay : NSObject <RCTBridgeModule>


### PR DESCRIPTION
* refer to: https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d

Hi,

This fix is to use newly introduced library header in ReactNative 0.40.0. Link below has details about the change:
https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d

without this patch, rn-alipay will not work in ReactNative 0.40.0 or above.

Thanks!